### PR TITLE
Add instructions for Windows setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,48 @@ Installation on macOS depends on [Homebrew](https://brew.sh/) and [ASDF](https:/
     # Copy to a folder in your path
     cp rez ~/bin/
 
+### Windows
+
+  1. **Install Elixir and Erlang.**
+
+     Download the Elixir web installer from https://elixir-lang.org/install.html#windows and install v1.14.2 or newer (the installer will give you a choice of versions during install). Installing Elixir will also install the appropriate version of Erlang by default. If you have a prior install of Erlang, you may need to check that it's compatible with latest Elixir.
+    
+     Verify your install in Powershell with
+    
+         > elixir -v
+         Erlang/OTP 25 [erts-13.0.4] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit:ns]
+         Elixir 1.14.2 (compiled with Erlang/OTP 25)
+   
+  2. **Install Node.**
+
+     Install [NodeJS 19](https://nodejs.org/).  A optional version manager like [NVM for Windows](https://github.com/coreybutler/nvm-windows) can make this easier.
+     
+  3. **Clone the repo.**
+  
+         > git clone git@github.com:mmower/rez.git
+         > cd rez
+      
+  4. **Install dependencies.**
+  
+         > npm install
+         > mix deps.get
+      
+  5. **Build the rez compiler binary.**
+  
+     From Powershell:
+     
+         > $env:BUILD_MODE = 'escript'; $env:MIX_ENV = 'prod'; mix escript.build
+     
+     Verify your build:
+     
+         > .\rez --version
+
+  6. **Put rez in your path.**
+
+     Edit your environment variables and add the repo to your PATH. Now you should be able to run `rez` from any directory in your shell, undecorated. Check that you can print the version from the root directory:
+
+         > cd \; rez version
+
 ### Other OS
 
 I'm hoping users of other platforms will give me the steps required to get it working for their platform.

--- a/lib/compiler/start_handlebars.ex
+++ b/lib/compiler/start_handlebars.ex
@@ -14,7 +14,10 @@ defmodule Rez.Compiler.StartHandlebars do
           compilation
       ) do
     try do
-      {version, 0} = System.cmd("handlebars", ["-v"])
+      {version, 0} = case :os.type() do
+        {:win32, _} -> System.cmd("cmd", ["/c", "handlebars", "-v"])
+        _ -> System.cmd("handlebars", ["-v"])
+      end
       Rez.Handlebars.start_link(cache_path)
       %{compilation | progress: ["Using handlebars version #{String.trim(version)}" | progress]}
     rescue

--- a/lib/handlebars.ex
+++ b/lib/handlebars.ex
@@ -61,8 +61,12 @@ defmodule Rez.Handlebars do
   end
 
   def run_handlebars(template_path, output_path, label) do
-    {time, result} =
-      :timer.tc(System, :cmd, ["handlebars", ["--simple", template_path, "-f", output_path]])
+    handlebars_args = ["--simple", template_path, "-f", output_path]
+    command = case :os.type() do
+      {:win32, _} -> ["cmd", ["/c", "handlebars"] ++ handlebars_args]
+      _ -> ["handlebars", handlebars_args]
+    end
+    {time, result} = :timer.tc(System, :cmd, command)
 
     Debug.dbg_log(
       :verbose,

--- a/rez.bat
+++ b/rez.bat
@@ -1,0 +1,9 @@
+@echo off
+
+rem Run the rez compiler
+rem escript is the directly-invokable executable on Windows,
+rem   and will be in your PATH after installing Elixir.
+rem %~dp0 is the directory of this batch script, which should
+rem   be colocated with the built rez compiler.
+rem %* passes along all arguments.
+escript %~dp0rez %*


### PR DESCRIPTION
Fixes #4. Adds a section to the README and makes a few small adjustments to support setup and build on Windows 11 with Powershell.

I've got a couple changes to the compiler source here that do platform detection ([following this pattern](https://blog.sethcorker.com/question/how-do-you-detect-what-os-you-re-running-in-elixir/)). Totally open to discussion about whether this is the best cross-platform way to invoke handlebars.

It's slightly less automated than *nix setup since it's not using a Homebrew equivalent to provide Elixir and Node, but it shouldn't require too much separate maintenance and the user ends up able to invoke `rez` from the terminal in the same way.